### PR TITLE
Update netssh.rb

### DIFF
--- a/lib/sshkit/sudo/backends_ext/netssh.rb
+++ b/lib/sshkit/sudo/backends_ext/netssh.rb
@@ -3,7 +3,7 @@ require 'io/console'
 module SSHKit
   module Backend
 
-    class Netssh < Printer
+    class Netssh < Abstract
       def sudo(*args)
         _execute!(:sudo, *args).success?
       end


### PR DESCRIPTION
Changed class hierarchy to match latest sshkit (see https://github.com/capistrano/sshkit/commit/4c41dde550277e54f601674a62539afcdb4adb5e).
